### PR TITLE
Use numbered arguments

### DIFF
--- a/mail/achievement_given.php
+++ b/mail/achievement_given.php
@@ -18,5 +18,5 @@ $subject = t('New Achievement – %s', $userBadge->getBadge()->getName());
 if ($userBadge->isGivenBySystem()) {
     $body = t("Congratulations! You got the achievement %s from the website.", $userBadge->getBadge()->getName());
 } else {
-    $body = t("Congratulations! You got the achievement %1$s from the user %s.", $userBadge->getBadge()->getName(), $userBadge->getAwardGrant()->getUser()->getUserName());
+    $body = t("Congratulations! You got the achievement %1$s from the user %2$s.", $userBadge->getBadge()->getName(), $userBadge->getAwardGrant()->getUser()->getUserName());
 }

--- a/mail/achievement_given.php
+++ b/mail/achievement_given.php
@@ -18,5 +18,5 @@ $subject = t('New Achievement – %s', $userBadge->getBadge()->getName());
 if ($userBadge->isGivenBySystem()) {
     $body = t("Congratulations! You got the achievement %s from the website.", $userBadge->getBadge()->getName());
 } else {
-    $body = t("Congratulations! You got the achievement %s from the user %s.", $userBadge->getBadge()->getName(), $userBadge->getAwardGrant()->getUser()->getUserName());
+    $body = t("Congratulations! You got the achievement %1$s from the user %s.", $userBadge->getBadge()->getName(), $userBadge->getAwardGrant()->getUser()->getUserName());
 }

--- a/mail/award_given.php
+++ b/mail/award_given.php
@@ -18,5 +18,5 @@ $subject = t('Awarded Award – %s', $userBadge->getBadge()->getName());
 if ($userBadge->isGivenBySystem()) {
     $body = t("Congratulations! You awarded the award %s from the website.", $userBadge->getBadge()->getName());
 } else {
-    $body = t("Congratulations! You awarded the award %s from the user %s.", $userBadge->getBadge()->getName(), $userBadge->getAwardGrant()->getUser()->getUserName());
+    $body = t("Congratulations! You awarded the award %1$s from the user %2$s.", $userBadge->getBadge()->getName(), $userBadge->getAwardGrant()->getUser()->getUserName());
 }


### PR DESCRIPTION
Using numbered arguments will allow translators to switch the arguments order to allow more correct translations.

